### PR TITLE
add ‘wrap’ syntax

### DIFF
--- a/vinergy/config.py
+++ b/vinergy/config.py
@@ -23,3 +23,10 @@ DBURL = {'host': 'localhost',
 
 ### Url length
 PAD = 3
+
+### Default syntax to fallback
+DEFAULT_SYNTAX = 'wrap'
+
+## Default wrap width
+DEFAULT_WIDTH = 80
+

--- a/vinergy/templates/paste.html
+++ b/vinergy/templates/paste.html
@@ -1,0 +1,13 @@
+$def with (url)
+
+$var snippet:
+
+<body>
+    <form action="${url}" method="post">
+        <p>Code:</p>
+        <textarea rows="25" cols="80" name="vimcn"></textarea><br>
+        <p>Filetype:</p>
+        <input name="lang" value="wrap" type="text">
+        <input value="submit" type="submit">
+    </form>
+</body>

--- a/vinergy/util/util.py
+++ b/vinergy/util/util.py
@@ -62,11 +62,16 @@ def name_count(count=0):
 
 def norm_filetype(syntax):
   """Normalize filetype"""
+  if syntax.startswith('wrap'):
+    try:
+      return 'wrap', int(syntax[4:])
+    except:
+      return 'wrap', None
   try:
     lexer = pygments.lexers.get_lexer_by_name(syntax)
-    return lexer.name.lower()
+    return lexer.name.lower(), None
   except:
-    return 'text'
+    return None, None
 
 
 def render(code, formatter, syntax):

--- a/vinergy/vinergy.py
+++ b/vinergy/vinergy.py
@@ -48,6 +48,8 @@ class Index:
         got = got.rsplit('/', 1)[0]
       else:
         syntax = None
+      if got.startswith('paste'):
+          return render.paste(config.URL);
       doc = model.get_code_by_name(got)
       # "got" nothing
       if not doc:
@@ -100,6 +102,10 @@ class Index:
     '''Insert new code'''
     try:
       code = web.input().vimcn
+      try:
+        lang = web.input().lang
+      except AttributeError:
+        lang = ''
       # Content must be longer than "print 'Hello, world!'"
       # or smaller than 64 KiB
       if (len(code) < 21) or (len(code)/1024 > 64): raise ValueError
@@ -113,7 +119,7 @@ class Index:
         epoch = time.mktime(datetime.datetime.utctimetuple(datetime.\
                                                            datetime.utcnow()))
         model.insert_code(oid, name, code, count, epoch)
-      raise util.response(' ' + config.URL + '/' + name + '\n')
+      raise util.response(' ' + config.URL + '/' + name + '/' + lang + '\n')
     except AttributeError:
       status = '400 Bad Request'
       raise util.response('Oops. Please Check your command.\n', status)


### PR DESCRIPTION
When using '/wrap' as postfix in URL, the code will be wrapped and displayed without line numbers.
An integer can be added following 'wrap' to indicate the width of a line. For example, 'wrap40' will wrap the code in a width of 40 characters.
NOTE: It is possible to perform an attack if the number follows WRAP is too large.
